### PR TITLE
2.1.3

### DIFF
--- a/actions/lib/formatters.py
+++ b/actions/lib/formatters.py
@@ -37,10 +37,16 @@ def branch_protection_to_dict(branch_protection):
                 result[attr] = {}
                 for attr2 in required_pull_request_reviews_attributes:
                     if attr2 == 'dismissal_users':
-                        users = [user.login for user in req_pr_reviews.dismissal_users]
+                        if req_pr_reviews.dismissal_users is not None:
+                            users = [user.login for user in req_pr_reviews.dismissal_users]
+                        else:
+                            users = None
                         result[attr][attr2] = users
                     elif attr2 == 'dismissal_teams':
-                        teams = [team.slug for team in req_pr_reviews.dismissal_teams]
+                        if req_pr_reviews.dismissal_teams is not None:
+                            teams = [team.slug for team in req_pr_reviews.dismissal_teams]
+                        else:
+                            teams = None
                         result[attr][attr2] = teams
                     else:
                         result[attr][attr2] = getattr(req_pr_reviews, attr2)

--- a/actions/update_branch_protection.py
+++ b/actions/update_branch_protection.py
@@ -43,6 +43,11 @@ class UpdateBranchProtectionAction(BaseGithubAction):
             user_push_restrictions = restrictions['user_push_restrictions']
             team_push_restrictions = restrictions['team_push_restrictions']
 
+        if not dismissal_users:
+            dismissal_users = NotSet
+        if not dismissal_teams:
+            dismissal_teams = NotSet
+
         branch.edit_protection(strict=strict, contexts=contexts,
                                enforce_admins=enforce_admins,
                                dismissal_users=dismissal_users,
@@ -64,9 +69,13 @@ if __name__ == '__main__':
     GITHUB_BRANCH = os.environ.get('GITHUB_BRANCH')
 
     # As produced by get_branch_protection action
-    BRANCH_PROTECTION = {'enforce_admins': True,
-                         'required_pull_request_reviews': None,
-                         'required_status_checks': {'contexts': [], 'strict': True},
+    BRANCH_PROTECTION = {'enforce_admins': False,
+                         'required_pull_request_reviews': {'dismiss_stale_reviews': False,
+                                                           'dismissal_teams': None,
+                                                           'dismissal_users': None,
+                                                           'require_code_owner_reviews': False,
+                                                           'required_approving_review_count': 0},
+                         'required_status_checks': None,
                          'restrictions': None
                          }
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - git
   - scm
   - serverless
-version: 2.1.2
+version: 2.1.3
 python_versions:
   - "3"
 author : StackStorm, Inc.


### PR DESCRIPTION
fix update_branch_protection action:
  dismissal users and teams can now be null in GitHub's API response